### PR TITLE
`docpad` was undefined, changed params and used new DocPad's helper func...

### DIFF
--- a/plugins/rest/out/rest.plugin.js
+++ b/plugins/rest/out/rest.plugin.js
@@ -16,15 +16,15 @@
       RestPlugin.prototype.name = 'rest';
 
       RestPlugin.prototype.serverAfter = function(_arg, next) {
-        var docpad, server,
+        var docpad,
           _this = this;
-        docpad = _arg.docpad, server = _arg.server;
-        docpad.server.post(/./, function(req, res, next) {
+        docpad = _arg.docpad;
+        docpad.getServer().post(/./, function(req, res, next) {
           if (_this.config.requireAuthentication && _this.docpad.getPlugin('authenticate').isMaintainer() === false) {
             res.send(405);
             return next();
           }
-          return docpad.documents.findOne({
+          return docpad.getCollection('documents').findOne({
             url: req.url
           }, function(err, document) {
             var key, value, _ref;

--- a/plugins/rest/src/rest.plugin.coffee
+++ b/plugins/rest/src/rest.plugin.coffee
@@ -7,16 +7,16 @@ module.exports = (BasePlugin) ->
 		name: 'rest'
 
 		# Run when the server setup has finished
-		serverAfter: ({docpad,server},next) ->
+		serverAfter: ({docpad},next) ->
 			# Hook into all post requests
-			docpad.server.post /./, (req,res,next) =>
+			docpad.getServer().post /./, (req,res,next) =>
 				# Check is maintainer
 				if @config.requireAuthentication and @docpad.getPlugin('authenticate').isMaintainer() is false
 					res.send(405) # Not authorized
 					return next()
 
 				# Fetch the document
-				docpad.documents.findOne url: req.url, (err,document) ->
+				docpad.getCollection('documents').findOne url: req.url, (err,document) ->
 					# Error?
 					return next(err)  if err
 


### PR DESCRIPTION
...tions.

In an first attempt to update the rest plugin to Docpad 6, I noticed that the `serverAfter` event is emitted with the `server` param, whereas the rest plugin receives a `{docpad,server}` param. So using it produces as is produces this error (when issueing `docpad server`) :

``` shell
$  docpad server
info: Welcome to DocPad v6.0.2
info: DocPad listening to http://localhost:9778/ on directory /Users/khalid_jebbari/Documents/Javascript/test-rest-docpad/out
error: Something went wrong with the action
error: An error occured: Cannot read property 'server' of undefined TypeError: Cannot read property 'server' of undefined
    at RestPlugin.serverAfter (/Users/khalid_jebbari/Documents/Javascript/test-rest-docpad/node_modules/docpad-plugin-rest/out/rest.plugin.js:22:15)
    at /Users/khalid_jebbari/node/lib/node_modules/docpad/out/lib/plugin.js:43:34
    at /Users/khalid_jebbari/node/lib/node_modules/docpad/node_modules/bal-util/out/lib/events.js:250:18
    at _Class.runTask (/Users/khalid_jebbari/node/lib/node_modules/docpad/node_modules/bal-util/out/lib/flow.js:265:9)
    at _Class.nextTask (/Users/khalid_jebbari/node/lib/node_modules/docpad/node_modules/bal-util/out/lib/flow.js:257:14)
    at _Class.run (/Users/khalid_jebbari/node/lib/node_modules/docpad/node_modules/bal-util/out/lib/flow.js:278:18)
    at _Class.sync (/Users/khalid_jebbari/node/lib/node_modules/docpad/node_modules/bal-util/out/lib/flow.js:301:12)
    at DocPad.emitSync (/Users/khalid_jebbari/node/lib/node_modules/docpad/node_modules/bal-util/out/lib/events.js:253:13)
    at /Users/khalid_jebbari/node/lib/node_modules/docpad/out/lib/docpad.js:2061:23
    at _Class.next (/Users/khalid_jebbari/node/lib/node_modules/docpad/out/lib/docpad.js:2171:24)

```

So I thought of changing the param to `{docpad}` only, requiring a small change in docpad itself (posting it in a few minutes). With these 2 changes, others errors were happening because 'server' isn't a property of docpad. So I update the plugin code to match the new API and use DocPad's helpers, and all errors disappeared when issueing a `docpad server`.

But I couldn't test it to make sure it works properly. For a reason I can't explain, this very small [gist](https://gist.github.com/2917870) with code to test a basic POST request to the server doesn't work, telling me `Cannot find module 'request'`, whereas I do have request installed globally...
