### PR TITLE
Adding support for Handlebars

### DIFF
--- a/plugins/handlebars/.npmignore
+++ b/plugins/handlebars/.npmignore
@@ -1,0 +1,9 @@
+.DS_Store
+.git*
+.travis*
+*.md
+Makefile
+
+src/
+out/test/
+test/

--- a/plugins/handlebars/History.md
+++ b/plugins/handlebars/History.md
@@ -1,0 +1,4 @@
+## History
+
+- v1.0.0 June 14, 2012
+	- Initial version of Handlebars plugin

--- a/plugins/handlebars/Makefile
+++ b/plugins/handlebars/Makefile
@@ -1,0 +1,9 @@
+# If you change something here, be sure to change it in package.json's scripts as well
+
+dev:
+	./node_modules/.bin/coffee -w -o out/ -c src/
+
+compile:
+	./node_modules/.bin/coffee -o out/ -c src/
+
+.PHONY: dev compile

--- a/plugins/handlebars/package.json
+++ b/plugins/handlebars/package.json
@@ -1,0 +1,47 @@
+{
+	"name": "docpad-plugin-handlebars",
+	"version": "2.0.0",
+	"description": "Adds support for the Handlebars templating engine to DocPad.",
+	"homepage": "https://github.com/bevry/docpad-extras",
+	"keywords": [
+		"docpad",
+		"docpad-plugin",
+		"handlebars",
+		"templating",
+		"templates",
+		"render",
+		"rendering"
+	],
+	"author": {
+		"name": "Mike Moulton",
+		"email": "mike@meltmedia.com",
+		"url": "http://meltmedia.com"
+	},
+	"bugs": {
+		"url": "https://github.com/bevry/docpad-extras/issues"
+	},
+	"repository" : {
+		"type": "git",
+		"url": "http://github.com/bevry/docpad-extras.git"
+	},
+	"licenses": [
+		{
+			"type": "MIT",
+			"url": "http://creativecommons.org/licenses/MIT/"
+		}
+	],
+	"dependencies": {
+		"handlebars": ">= 1.0.5beta"
+	},
+	"devDependencies": {
+		"coffee-script": "1.3.x"
+	},
+	"engines" : {
+		"node": ">=0.4.0",
+	  "docpad": "6.x"
+	},
+	"main": "./out/handlebars.plugin.js",
+	"scripts": {
+		"test": "node ./test/handlebars.test.js"
+	}
+}

--- a/plugins/handlebars/src/handlebars.plugin.coffee
+++ b/plugins/handlebars/src/handlebars.plugin.coffee
@@ -1,0 +1,40 @@
+module.exports = (BasePlugin) ->
+
+  # Define Plugin
+  class HandlebarsPlugin extends BasePlugin
+
+    # Plugin name
+    name: 'handlebars'
+
+    # Plugin priority
+    priority: 725
+
+    # Handlebars
+    Handlebars: null
+
+    # Constructor
+    constructor: ->
+      super
+      docpad = @docpad
+      config = @config
+
+      Handlebars = @Handlebars = require 'handlebars'
+
+      # Add helpers, if defined in docpad.cson
+      if @config.helpers
+        Handlebars.registerHelper(name, helper) for name, helper of @config.helpers
+
+    # Render some content
+    render: (opts, next) ->
+      # Prepare
+      {inExtension,outExtension,templateData,file,content} = opts
+      Handlebars = @Handlebars
+
+      try
+        if inExtension in ['hb', 'hbs', 'handlebars']
+          opts.content = Handlebars.compile(content)(templateData)
+
+        return next()
+
+      catch err
+        return next(err)

--- a/plugins/handlebars/src/handlebars.tester.coffee
+++ b/plugins/handlebars/src/handlebars.tester.coffee
@@ -1,0 +1,4 @@
+# Export Plugin Tester
+module.exports = (testers) ->
+	# Define My Tester
+	class MyTester extends testers.RendererTester

--- a/plugins/handlebars/test/docpad.cson
+++ b/plugins/handlebars/test/docpad.cson
@@ -1,0 +1,7 @@
+{
+  plugins:
+    handlebars:
+      helpers:
+        helperTest: () ->
+          output = "Testing Helpers"
+}

--- a/plugins/handlebars/test/handlebars.test.js
+++ b/plugins/handlebars/test/handlebars.test.js
@@ -1,0 +1,2 @@
+// Test our plugin using DocPad's Testers
+require('docpad').require('testers').test({pluginPath: __dirname+'/..'});

--- a/plugins/handlebars/test/out-expected/handlebars-helper.html
+++ b/plugins/handlebars/test/out-expected/handlebars-helper.html
@@ -1,0 +1,1 @@
+<h1>Testing Helpers</h1>

--- a/plugins/handlebars/test/out-expected/handlebars.html
+++ b/plugins/handlebars/test/out-expected/handlebars.html
@@ -1,0 +1,1 @@
+<h1>Handlebars Example</h1>

--- a/plugins/handlebars/test/src/documents/handlebars-helper.html.hbs
+++ b/plugins/handlebars/test/src/documents/handlebars-helper.html.hbs
@@ -1,0 +1,1 @@
+<h1>{{helperTest}}</h1>

--- a/plugins/handlebars/test/src/documents/handlebars.html.hbs
+++ b/plugins/handlebars/test/src/documents/handlebars.html.hbs
@@ -1,0 +1,4 @@
+---
+example: 'Handlebars Example'
+---
+<h1>{{document.example}}</h1>


### PR DESCRIPTION
Here is a plugin to support the Handlebars template language (an extension of Mustache).

See: http://handlebarsjs.com for more info on the language.
