### PR TITLE
Custom error page handling

### DIFF
--- a/plugins/errors/errors.plugin.coffee
+++ b/plugins/errors/errors.plugin.coffee
@@ -38,38 +38,27 @@ module.exports = (BasePlugin) ->
 
     files: {}
 
-    prefixMatch: (n1, n2) ->
-      n1 = Number(n1)
-      n2 = Number(n2)
-
-      n1 = Math.floor(n1/100)
-      n2 = Math.floor(n2/100)
-
-      return (n1 == n2)
-
     findClosest: (code) ->
+      code = code.toString()
       match = null
-      for key, value of CODE
-        if @files.hasOwnProperty(key) && code >= Number(key)
-          match = key
-          # exact match exit
-          if Number(key) == code
-            break
+      count = 2
 
-      if match == null
-        for key, value of @files
-          match = key
-        unless match
+      while match == null
+        if @files.hasOwnProperty(code)
           match = code
-
+        else
+          code = code.substr(0, count)
+          while code.length < 3
+            code += 'x'
+          count -= 1
       return match
 
     generateAfter: ->
       fileList = fs.readdirSync(@docpad.config.outPath)
 
       for file in fileList
-        if file.match /^[0-9]{3}\.html/
-          code = file.match /^([0-9]{3})\.html/
+        if file.match /^[0-9x]{3}\.html/
+          code = file.match /^([0-9x]{3})\.html/
           @files[code[1]] = path.join(@docpad.config.outPath, file)
 
     serverAfter: (opts) ->

--- a/plugins/errors/errors.plugin.coffee
+++ b/plugins/errors/errors.plugin.coffee
@@ -1,0 +1,56 @@
+# Export Plugin
+module.exports = (BasePlugin) ->
+  express = require('express')
+  path = require('path')
+  fs = require('fs')
+
+  # Define Plugin
+  class Errors extends BasePlugin
+    # Plugin name
+    name: 'errors'
+
+    files: {}
+
+    findClosest: (code) ->
+      for key, value of @files
+        if Number(key) == code
+          return value
+
+      return null
+
+    generateAfter: ->
+      fileList = fs.readdirSync(@docpad.config.outPath)
+
+      for file in fileList
+        if file.match /^[0-9]{3}\.html/
+          code = file.match /^([0-9]{3})\.html/
+          @files[code[1]] = path.join(@docpad.config.outPath, file)
+
+    serverAfter: (opts) ->
+      {server} = (opts)
+      self = @
+
+      server.use (req, res, next) ->
+        file = self.findClosest(404)
+        # Assume 404 for now
+        if path.existsSync file
+          data = fs.readFileSync(file, 'utf8')
+          res.writeHead(404, 'Not Found')
+          res.write(data)
+        else
+          res.writeHead(404, 'Not Found')
+          res.write('404 NOT FOUND')
+
+        res.end()
+
+      server.use (err, req, res, next) ->
+        file = self.findClosest(500)
+        if path.existsSync file
+          res.writeHead(500, 'Internal Server Error')
+          data = fs.readFileSync(file, 'utf8')
+          res.write(data)
+        else
+          res.writeHead(500, 'Internal Server Error')
+          res.write('500 INTERNAL SERVER ERROR')
+
+        res.end()

--- a/plugins/errors/errors.plugin.coffee
+++ b/plugins/errors/errors.plugin.coffee
@@ -56,6 +56,12 @@ module.exports = (BasePlugin) ->
           if Number(key) == code
             break
 
+      if match == null
+        for key, value of @files
+          match = key
+        unless match
+          match = code
+
       return match
 
     generateAfter: ->
@@ -73,7 +79,7 @@ module.exports = (BasePlugin) ->
       server.use (req, res, next) ->
         code = self.findClosest(404)
         # Assume 404 for now
-        if path.existsSync self.files[code]
+        if self.files.hasOwnProperty(code) && path.existsSync self.files[code]
           data = fs.readFileSync(self.files[code], 'utf8')
           res.writeHead(code, CODE[code])
           res.write(data)
@@ -85,7 +91,7 @@ module.exports = (BasePlugin) ->
 
       server.use (err, req, res, next) ->
         code = self.findClosest(500)
-        if path.existsSync self.files[code]
+        if self.files.hasOwnProperty(code) && path.existsSync self.files[code]
           res.writeHead(code, CODE[code])
           data = fs.readFileSync(self.files[code], 'utf8')
           res.write(data)

--- a/plugins/errors/package.json
+++ b/plugins/errors/package.json
@@ -5,7 +5,8 @@
   "homepage": "https://github.com/ncrohn/docpad-plugin-errors",
   "keywords": [
     "docpad",
-    "docpad-plugin"
+    "docpad-plugin",
+    "error pages"
   ],
   "author": "Nick Crohn <nick@meltmedia.com> (nickcrohn.com)",
   "bugs": {

--- a/plugins/errors/package.json
+++ b/plugins/errors/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "docpad-plugin-errors",
+  "version": "0.1.0",
+  "description": "DocPad plugin which adds the ability to handle rendering error pages",
+  "homepage": "https://github.com/ncrohn/docpad-plugin-errors",
+  "keywords": [
+    "docpad",
+    "docpad-plugin"
+  ],
+  "author": "Nick Crohn <nick@meltmedia.com> (nickcrohn.com)",
+  "bugs": {
+    "url": "https://github.com/ncrohn/docpad-plugin-errors/issues"
+  },
+  "repository" : {
+    "type": "git",
+    "url": "http://github.com/ncrohn/docpad-plugin-errors.git"
+  },
+  "engines" : {
+    "node": ">=0.4.0",
+    "docpad": "6.x"
+  },
+  "dependencies": {
+    "express": "2.5.10"
+  },
+  "main": "./errors.plugin.coffee"
+}


### PR DESCRIPTION
This plugin is to coincide with the pull request on docpad:master of mine. It allows for bypass of docpads generic 404 response in express.

This will look at your out directory and serve up the closest matching error page.

Say someone triggers a 404 response it will find all 000-999.html files and match the closest one and serve up its contents.
