### PR TITLE
Target specific documents in related plugins

### DIFF
--- a/plugins/related/src/related.plugin.coffee
+++ b/plugins/related/src/related.plugin.coffee
@@ -25,10 +25,11 @@ module.exports = (BasePlugin) ->
 			docpad = @docpad
 			logger = @logger
 			documents = docpad.getCollection('documents')
+			targetedDocuments = if @config.collectionName then docpad.getCollection(@config.collectionName) else documents
 			docpad.log 'debug', 'Generating relations'
 
 			# Cycle through all our documents
-			documents.forEach (document) ->
+			targetedDocuments.forEach (document) ->
 				# Prepare
 				tags = document.get('tags') or []
 
@@ -53,7 +54,7 @@ module.exports = (BasePlugin) ->
 		renderBefore: (opts,next) ->
 			# Prepare
 			docpad = @docpad
-			documents = docpad.getCollection('documents')
+			documents = docpad.getCollection(@config.collectionName or 'documents')
 
 			# Cycle through all our documents
 			documents.forEach (document) ->


### PR DESCRIPTION
 Added a collectionName config option to the relatedPlugin to avoid unnecessary loop over the all documents collection if needed.

In my use case (900 docs), the regeneration time went down from 40 to 2 seconds. I feel much happier now.

On a side note, there's an inconsistency between the plugin name between _related_ and _relations_.
