### PR TITLE
Allow to --require ruby libraries defined in config

### DIFF
--- a/plugins/sass/src/sass.plugin.coffee
+++ b/plugins/sass/src/sass.plugin.coffee
@@ -54,6 +54,11 @@ module.exports = (BasePlugin) ->
 				if config.outputStyle
 					command.push('--style')
 					command.push(config.outputStyle)
+				if config.requireLibraries
+					for name in config.requireLibraries
+						if (typeof name == 'function') continue
+						command.push('--require');
+						command.push(name);
 
 				# Spawn the appropriate process to render the content
 				balUtil.spawn command, commandOpts, (err,stdout,stderr,code,signal) ->


### PR DESCRIPTION
I'd like to use ruby libraries from sass. The appended code will require libraries listed in the "requireLibraries" configuration property by appending them using the --require option of the sass command.

``` javascript
/* file: package.json */
// ...
"plugins": {
    // ...
    "sass": {
        // ...
        "requireLibraries": [ "susy", "compass-colors" ]
    }
}
```
