### PR TITLE
Fix Markdown issues by switching the parser to Marked

### DIFF
--- a/plugins/markdown/package.json
+++ b/plugins/markdown/package.json
@@ -28,7 +28,7 @@
 		"docpad": "6.x"
 	},
 	"dependencies": {
-		"github-flavored-markdown": "1.0.x"
+        "marked": ">=0.2.5"
 	},
 	"devDependencies": {
 		"coffee-script": "1.3.x"

--- a/plugins/markdown/src/markdown.plugin.coffee
+++ b/plugins/markdown/src/markdown.plugin.coffee
@@ -13,10 +13,17 @@ module.exports = (BasePlugin) ->
 			# Check our extensions
 			if inExtension in ['md','markdown'] and outExtension in [null,'html']
 				# Requires
-				markdown = require('github-flavored-markdown')
+				marked = require 'marked'
+
+				marked.setOptions({
+					gfm: true
+					pedantic: false
+					sanitize: true
+					highlight: null
+				})
 
 				# Render
-				opts.content = markdown.parse(opts.content)
+				opts.content = marked(opts.content)
 
 			# Done
 			next()


### PR DESCRIPTION
The official [Github-Flavored-Markdown](https://npmjs.org/package/github-flavored-markdown) uses a very old (at the time of writing, _9 months_) version of Showdown.js.

This may not seem like a problem, however when using GitHub-style code blocks, odd results can appear.

An example is when using a code block with `coffeescript` explicitly stated as the language in a Markdown document, any of the code that has two successful newlines `\n` will embed a `pre code` element inside of the `div.highlight pre` element where the rest of the code resides.

Not only does [Marked](https://github.com/chjj/marked) properly support GFM, but it is also currently the fastest Javascript parser for Markdown. It is well maintained and should provide a much more stable library as it is actively receiving contributions.
