### PR TITLE
Syntax Highlighting Support for Markdown's code block

### DIFF
--- a/plugins/markdown/README.md
+++ b/plugins/markdown/README.md
@@ -10,9 +10,47 @@ Convention:  `.html.md|markdown`
 npm install --save docpad-plugin-markdown
 ```
 
+## Options
+
+You can pass marked options. Put followings in your `package.json` of docpad project:
+
+```
+...
+  "docpad": {
+    "plugins": {
+      "markdown": {
+        "gfm": true,
+        "pedantic": false,
+        "sanitize": true,
+        "highlight": false //for highlighting markdown's code block
+      }
+    }
+...
+```
+
+It will override default options (See details on https://github.com/chjj/marked).
+
+### Highlighting
+
+It depends on '[highlight.js](https://github.com/isagalaev/highlight.js)' module. If you want to highlight your site, do following steps:
+
+Turn on highlight feature in your `package.json`:
+
+```
+...
+  "docpad": {
+    "plugins": {
+      "markdown": {
+        "highlight": true
+      }
+    }
+...
+```
+
+Find your style on [test page](http://softwaremaniacs.org/media/soft/highlight/test.html). You can download your [style](https://github.com/isagalaev/highlight.js/tree/master/src/styles).
 
 ## History
-You can discover the history inside the `History.md` file
+You can discolver the history inside the `History.md` file
 
 
 ## License

--- a/plugins/markdown/package.json
+++ b/plugins/markdown/package.json
@@ -28,7 +28,9 @@
 		"docpad": "6.x"
 	},
 	"dependencies": {
-        "marked": ">=0.2.5"
+		"marked": ">=0.2.5",
+		"highlight.js": ">=7.2.0",
+		"underscore": ">=1.3.3"
 	},
 	"devDependencies": {
 		"coffee-script": "1.3.x"

--- a/plugins/markdown/package.json
+++ b/plugins/markdown/package.json
@@ -28,7 +28,7 @@
 		"docpad": "6.x"
 	},
 	"dependencies": {
-		"github-flavored-markdown": "1.0.x"
+        "marked": ">=0.2.5"
 	},
 	"devDependencies": {
 		"coffee-script": "1.3.x"

--- a/plugins/markdown/src/markdown.plugin.coffee
+++ b/plugins/markdown/src/markdown.plugin.coffee
@@ -24,17 +24,27 @@ module.exports = (BasePlugin) ->
 
 			# Check our extensions
 			if inExtension in ['md','markdown'] and outExtension in [null,'html']
+				# Default options
+				options =
+					gfm: true
+					pedantic: false
+					sanitize: true
+					highlight: null
+
+				# Merge options
 				if @config.highlight
-					marked.setOptions
-						gfm: true
-						pedantic: false
-						sanitize: true
+					options = _.extend options, @config,
 						highlight: (code, language) ->
 							lang = makesure language
 							if lang
 								return hl.highlight(lang, code).value
 							else
 								return hl.highlightAuto(code).value
+				else
+					options = _.extend options, @config
+
+
+				marked.setOptions options
 
 				# Render
 				opts.content = marked opts.content

--- a/plugins/markdown/src/markdown.plugin.coffee
+++ b/plugins/markdown/src/markdown.plugin.coffee
@@ -13,10 +13,17 @@ module.exports = (BasePlugin) ->
 			# Check our extensions
 			if inExtension in ['md','markdown'] and outExtension in [null,'html']
 				# Requires
-				markdown = require('github-flavored-markdown')
+				marked = require 'marked'
+
+				marked.setOptions({
+					gfm: true
+					pedantic: false
+					sanitize: true
+					highlight: null
+				})
 
 				# Render
-				opts.content = markdown.parse(opts.content)
+				opts.content = marked(opts.content)
 
 			# Done
 			next()

--- a/plugins/markdown/src/markdown.plugin.coffee
+++ b/plugins/markdown/src/markdown.plugin.coffee
@@ -1,5 +1,17 @@
 # Export Plugin
 module.exports = (BasePlugin) ->
+	# Requires
+	marked = require 'marked'
+	hl = require 'highlight.js'
+	_ = require 'underscore'
+
+	makesure = (name) ->
+		if _.isString name
+			ret = name.trim()
+			return ret if _(hl.LANGUAGES).has ret
+
+		null
+
 	# Define Plugin
 	class MarkdownPlugin extends BasePlugin
 		# Plugin name
@@ -12,18 +24,20 @@ module.exports = (BasePlugin) ->
 
 			# Check our extensions
 			if inExtension in ['md','markdown'] and outExtension in [null,'html']
-				# Requires
-				marked = require 'marked'
-
-				marked.setOptions({
-					gfm: true
-					pedantic: false
-					sanitize: true
-					highlight: null
-				})
+				if @config.highlight
+					marked.setOptions
+						gfm: true
+						pedantic: false
+						sanitize: true
+						highlight: (code, language) ->
+							lang = makesure language
+							if lang
+								return hl.highlight(lang, code).value
+							else
+								return hl.highlightAuto(code).value
 
 				# Render
-				opts.content = marked(opts.content)
+				opts.content = marked opts.content
 
 			# Done
 			next()


### PR DESCRIPTION
I Added Syntax Highlighting Support for Markdown's code block

It use [highlight.js](https://github.com/isagalaev/highlight.js) on @chase's work(#15)

See details on https://github.com/pismute/docpad-extras/tree/markdown/plugins/markdown.
