### PR TITLE
Highlight.js Plugin as Submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "plugins/highlightjs"]
+	path = plugins/highlightjs
+	url = https://chase@github.com/chase/docpad-plugin-highlightjs.git


### PR DESCRIPTION
Regarding chase/docpad-plugin-highlightjs#4

Instead of merging to `bevry/docpad-extras`, I believe adding the `chase/docpad-plugin-highlightjs` repository as a submodule would be more beneficial.

The main benefit is that you still have control over which of my updates make it into `bevry/docpad-extras` while I am still able to freely update the plugin. This will avoid heavy use of the `dev` branch and simplify any merge processes.

Another benefit is that notifications I receive will only pertain to the plugins which I maintain, allowing me to more easily focus on the Highlight.js plugin.

There are [a few caveats to Submodules](http://git-scm.com/book/en/Git-Tools-Submodules), mainly a few issues about pulling updates into the repository.

You can also [automatically init and update on fetch and pull](http://hedgehogshiatus.com/git-submodules-automatic-init-and-update-on-f-69372) if you prefer.
